### PR TITLE
feat(profile): add ProfileSkillsPage for user's skills display

### DIFF
--- a/src/pages/profile-skills/ProfileSkillsPage.tsx
+++ b/src/pages/profile-skills/ProfileSkillsPage.tsx
@@ -1,3 +1,11 @@
+import { useSelector } from '@app/store'
+import { selectAllSkills, selectSkillsLoading, SkillCardContainer } from '@entities/skill'
+import { useAuthState } from '@features/auth'
+import useAuxData from '@shared/hooks/useAuxData'
+import Button from '@shared/ui/button/Button'
+import SectionUI from '@shared/ui/section/SectionUI'
+import { useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
 import styles from './profile-skills-page.module.scss'
 
 /**
@@ -10,11 +18,64 @@ import styles from './profile-skills-page.module.scss'
  */
 
 function ProfileSkillsPage() {
+  const navigate = useNavigate()
+  const { currentUserId } = useAuthState()
+  const allSkills = useSelector(selectAllSkills)
+  const skillsLoading = useSelector(selectSkillsLoading)
+  const { categoriesData, citiesData, isLoading: auxLoading } = useAuxData()
+
+  const userSkills = useMemo(() => {
+    if (!currentUserId)
+      return []
+    return allSkills.filter((skill) => skill.userId === currentUserId)
+  }, [allSkills, currentUserId])
+
+  const handleGoToMain = () => {
+    navigate('/')
+  }
+
+  if (skillsLoading || auxLoading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loader}>Загрузка...</div>
+      </div>
+    )
+  }
+
+  const hasSkills = userSkills.length > 0
+
   return (
-    <section className={styles['profile-skills']}>
-      <h1>Мои навыки</h1>
-      <p>Страница навыков пользователя</p>
-    </section>
+    <div className={styles.container}>
+      {!hasSkills
+        ? (
+            <div className={styles.emptyState}>
+              <div className={styles.emptyIcon}>✎</div>
+              <h3 className={styles.emptyTitle}>У вас пока нет навыков</h3>
+              <p className={styles.emptyText}>
+                Вы еще не создали ни одного навыка. Вернитесь на главную страницу, чтобы посмотреть предложения других пользователей.
+              </p>
+              <Button
+                title="На главную"
+                onClick={handleGoToMain}
+                variant="primary"
+                className={styles.goToMainButton}
+              />
+            </div>
+          )
+        : (
+            <SectionUI title="Мои навыки" className={styles.section}>
+              {userSkills.map((skill) => (
+                <SkillCardContainer
+                  key={skill.id}
+                  skillId={skill.id}
+                  categories={categoriesData?.categories || []}
+                  subcategories={categoriesData?.subcategories || []}
+                  cities={citiesData}
+                />
+              ))}
+            </SectionUI>
+          )}
+    </div>
   )
 }
 

--- a/src/pages/profile-skills/profile-skills-page.module.scss
+++ b/src/pages/profile-skills/profile-skills-page.module.scss
@@ -1,3 +1,80 @@
-.profile-skills {
-  // Стили для страницы навыков
+// profile-skills-page.module.scss
+.container {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 80px 24px;
+  background: #fafafa;
+  border-radius: 20px;
+  border: 2px dashed #e0e0e0;
+  margin-top: 40px;
+}
+
+.emptyIcon {
+  font-size: 80px;
+  color: #e0e0e0;
+  margin-bottom: 32px;
+  line-height: 1;
+}
+
+.emptyTitle {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: #666;
+}
+
+.emptyText {
+  font-size: 16px;
+  color: #888;
+  margin: 0;
+  max-width: 400px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.goToMainButton {
+  margin-top: 24px;
+  min-width: 200px;
+}
+
+.loader {
+  padding: 24px;
+  text-align: center;
+  color: #888;
+  background: #fff;
+  border-radius: 12px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 16px;
+  }
+
+  .emptyState {
+    padding: 60px 16px;
+    margin-top: 20px;
+  }
+
+  .emptyIcon {
+    font-size: 60px;
+  }
+
+  .emptyTitle {
+    font-size: 20px;
+  }
+
+  .goToMainButton {
+    min-width: 180px;
+  }
 }


### PR DESCRIPTION
## Описание

Добавлена страница "Мои навыки" в профиле пользователя для просмотра собственных навыков.

## Изменения

- Создан компонент `ProfileSkillsPage` (`src/pages/profile-skills/`)
- Добавлены стили с поддержкой responsive layout
- Реализован Empty State с кнопкой навигации на главную
- Интегрирован `SkillCardContainer` для отображения карточек

## Детали реализации

- Фильтрация навыков по `userId` через `useMemo`
- Использование `useAuxData` для загрузки справочников (категории, города)
- Обработка loading состояния для skills и aux data

## Тестирование

- [x] TypeScript компиляция без ошибок (`tsc --noEmit`)
- [x] ESLint без ошибок

## Скриншоты

#### Светлая тема:

<img width="1440" height="1152" alt="изображение" src="https://github.com/user-attachments/assets/805f8f29-8182-45dc-bed7-0e076ec28a54" />

#### Темная тема:

<img width="1440" height="1152" alt="изображение" src="https://github.com/user-attachments/assets/3e5777f5-9abd-4f1e-bca5-d56a557cc489" />

## Related

- Closes #5 